### PR TITLE
Remove ibu resource namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,27 +248,27 @@ lca-stage-idle: credentials/backup-secret.json
 .PHONY: lca-wait-for-idle
 lca-wait-for-idle: CLUSTER=$(RECIPIENT_VM_NAME)
 lca-wait-for-idle:
-	$(oc) wait --timeout=30m --for=condition=Idle=true ibu -n default upgrade
+	$(oc) wait --timeout=30m --for=condition=Idle=true ibu upgrade
 
 .PHONY: lca-stage-prep
 lca-stage-prep: CLUSTER=$(RECIPIENT_VM_NAME)
 lca-stage-prep:
-	$(oc) patch --type=json ibu -n default upgrade --type merge -p '{"spec": { "stage": "Prep"}}'
+	$(oc) patch --type=json ibu upgrade --type merge -p '{"spec": { "stage": "Prep"}}'
 
 .PHONY: lca-wait-for-prep
 lca-wait-for-prep: CLUSTER=$(RECIPIENT_VM_NAME)
 lca-wait-for-prep:
-	$(oc) wait --timeout=30m --for=condition=PrepCompleted=true ibu -n default upgrade
+	$(oc) wait --timeout=30m --for=condition=PrepCompleted=true ibu upgrade
 
 .PHONY: lca-stage-upgrade
 lca-stage-upgrade: CLUSTER=$(RECIPIENT_VM_NAME)
 lca-stage-upgrade:
-	$(oc) patch --type=json ibu -n default upgrade --type merge -p '{"spec": { "stage": "Upgrade"}}'
+	$(oc) patch --type=json ibu upgrade --type merge -p '{"spec": { "stage": "Upgrade"}}'
 
 .PHONY: lca-wait-for-upgrade
 lca-wait-for-upgrade: CLUSTER=$(RECIPIENT_VM_NAME)
 lca-wait-for-upgrade:
-	$(oc) wait --timeout=30m --for=condition=UpgradeCompleted=true ibu -n default upgrade
+	$(oc) wait --timeout=30m --for=condition=UpgradeCompleted=true ibu upgrade
 
 .PHONY: ssh
 ssh: $(SSH_KEY_PRIV_PATH)

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ lifecycle-agent-deploy: lifecycle-agent
 .PHONY: lca-stage-idle
 lca-stage-idle: CLUSTER=$(RECIPIENT_VM_NAME)
 lca-stage-idle: credentials/backup-secret.json
-	$(oc) create secret generic seed-pull-secret -n default --from-file=.dockerconfigjson=credentials/backup-secret.json \
+	$(oc) create secret generic seed-pull-secret -n openshift-lifecycle-agent --from-file=.dockerconfigjson=credentials/backup-secret.json \
 		--type=kubernetes.io/dockerconfigjson --dry-run=client -oyaml \
 		| $(oc) apply -f -
 	SEED_VERSION=$(SEED_VERSION) SEED_IMAGE=$(SEED_IMAGE) envsubst < imagebasedupgrade.yaml | $(oc) apply -f -

--- a/imagebasedupgrade.yaml
+++ b/imagebasedupgrade.yaml
@@ -2,7 +2,6 @@ apiVersion: lca.openshift.io/v1alpha1
 kind: ImageBasedUpgrade
 metadata:
     name: upgrade
-    namespace: default
 spec:
     stage: Idle
     seedImageRef:


### PR DESCRIPTION
This PR adjusts the Makefile to the IBU resource being now [cluster-scoped](https://github.com/openshift-kni/lifecycle-agent/pull/138). It also moves the seed pull secret to the default LCA operator namespace, i.e. `openshift-lifecycle-agent`.