### PR TITLE
Use recert stable tag

### DIFF
--- a/recert_script.sh
+++ b/recert_script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RECERT_IMAGE=quay.io/edge-infrastructure/recert:latest
+RECERT_IMAGE=quay.io/edge-infrastructure/recert:v0
 BACKUP_DIR=/var/tmp/recert
 KUBECONFIG=/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost.kubeconfig
 ETCD_IMAGE=$(jq -r '.spec.containers[] | select(.name == "etcd") | .image' /etc/kubernetes/manifests/etcd-pod.yaml)


### PR DESCRIPTION
The `:latest` tag of the recert image is not stable, it contains changes
from the `main` branch. We should default to the `:v0` tag instead which
we merge into less often.