### PR TITLE
New `DISABLE_IBU_ROLLBACK` option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ SNO_DIR = ./bip-orchestrate-vm
 # Define precache mode (partition or directory)
 PRECACHE_MODE ?= partition
 
+# Define the rollback mode
+DISABLE_IBU_ROLLBACK ?= false
+
 -include .config-override
 include network.env
 
@@ -367,10 +370,11 @@ lifecycle-agent-deploy: lifecycle-agent
 .PHONY: lca-stage-idle
 lca-stage-idle: CLUSTER=$(RECIPIENT_VM_NAME)
 lca-stage-idle: credentials/backup-secret.json
+	# DISABLE_IBU_ROLLBACK
 	$(oc) create secret generic seed-pull-secret -n openshift-lifecycle-agent --from-file=.dockerconfigjson=credentials/backup-secret.json \
 		--type=kubernetes.io/dockerconfigjson --dry-run=client -oyaml \
 		| $(oc) apply -f -
-	SEED_VERSION=$(SEED_VERSION) SEED_IMAGE=$(SEED_IMAGE) envsubst < imagebasedupgrade.yaml | $(oc) apply -f -
+	SEED_VERSION=$(SEED_VERSION) SEED_IMAGE=$(SEED_IMAGE) DISABLE_IBU_ROLLBACK=$(DISABLE_IBU_ROLLBACK) envsubst < imagebasedupgrade.yaml | $(oc) apply -f -
 
 .PHONY: lca-stage-prep
 lca-stage-prep: CLUSTER=$(RECIPIENT_VM_NAME)

--- a/imagebasedupgrade.yaml
+++ b/imagebasedupgrade.yaml
@@ -1,11 +1,15 @@
 apiVersion: lca.openshift.io/v1alpha1
 kind: ImageBasedUpgrade
 metadata:
-    name: upgrade
+  name: upgrade
 spec:
-    stage: Idle
-    seedImageRef:
-        version: ${SEED_VERSION}
-        image: ${SEED_IMAGE}
-        pullSecretRef:
-          name: seed-pull-secret
+  stage: Idle
+  seedImageRef:
+    version: ${SEED_VERSION}
+    image: ${SEED_IMAGE}
+    pullSecretRef:
+      name: seed-pull-secret
+  autoRollbackOnFailure:
+    disabledForPostRebootConfig: $(DISABLE_IBU_ROLLBACK)
+    disabledForUpgradeCompletion: $(DISABLE_IBU_ROLLBACK)
+    disabledInitMonitor: $(DISABLE_IBU_ROLLBACK)


### PR DESCRIPTION
Allow users to set `DISABLE_IBU_ROLLBACK` to `"true"` in order to
disable rollback. This is useful in the CI where we're not interested in
rolling back on failure (as the original cluster has no use for us), but
instead we're more interested in collecting logs from the new failed
stateroot