### PR TITLE
Fix and improve /var/lib/container's directory-method and fix variable priority in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,14 @@ MAKEFLAGS += --no-builtin-rules
 IMAGE_BASED_DIR = .
 SNO_DIR = ./bip-orchestrate-vm
 
+-include .config-override
+
 # Define precache mode (partition or directory)
 PRECACHE_MODE ?= partition
 
 # Define the rollback mode
 DISABLE_IBU_ROLLBACK ?= false
 
--include .config-override
 include network.env
 
 default: help

--- a/ostree-var-lib-containers-machineconfig.yaml
+++ b/ostree-var-lib-containers-machineconfig.yaml
@@ -18,9 +18,9 @@ spec:
         - mode: 493
           path: /usr/local/bin/create_shared_containers_dir.sh
           contents:
-            source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAojCiMgVGhpcyBzY3JpcHQgd2lsbCBjcmVhdGUgdW5kZXIgL3N5c3Jvb3QgYSBkaXJlY3RvcnkgdGhhdCB3aWxsIGJlIHVzZWQgdG8gc2hhcmUKIyBjb250YWluZXJzIGJldHdlZW4gdGhlIGRpZmZlcmVudCBzdGF0ZXJvb3RzCiMKc2V0IC14CmRpcj1jb250YWluZXJzCiMgSWYgdGhlIGRlc3RpbmF0aW9uIHNoYXJlZCBkaXIgZG9lcyBub3QgZXhpc3QsIHdlIG5lZWQgdG8gY3JlYXRlIGl0CmlmIFtbICEgLWQgL3N5c3Jvb3QvIiRkaXIiIF1dOyB0aGVuCiAgIGVjaG8gIi9zeXNyb290LyRkaXIgbm90IGV4aXN0aW5nLCBjcmVhdGluZyIKICAgZWNobyAiRnJlZWluZyBzcGFjZSBpbiBwcmV2aW91cyAvdmFyL2xpYi9jb250YWluZXJzIgogICAjIEZpcnN0IHdlIHdpbGwgZGVsZXRlIHRoZSBjb250ZW50cyBvZiB0aGUgb2xkIC92YXIvbGliL2NvbnRhaW5lcnMgdG8gbm90CiAgICMgaGF2ZSBoaWRkZW4gdXNlZCBzcGFjZSwgc2luY2Ugd2Ugd2lsbCBtb3VudCBvbiB0b3Agb2YgaXQKICAgcm0gLWZyIC92YXIvbGliL2NvbnRhaW5lcnMvKgogICB0bXA9JChta3RlbXAgLWQpCiAgICMgL3N5c3Jvb3QgaXMgcmVhZC1vbmx5LCBhbmQgaWYgd2UgcmVtb3VudCBpdCByZWFkd3JpdGUsIHdlIHdvbnQgYmUgYWJsZSB0byByZXZlcnQgaXQgYmFjayB0byByZWFkLW9ubHkKICAgIyB0byBvdmVyY29tZSB0aGlzLCB3ZSB3aWxsIGRvIGEgYmluZCBtb3VudCBzb21ld2hlcmUgZWxzZSwgYW5kIGNoYW5nZSB0aGF0IG5ldyBtb3VudCB0byByZWFkLXdyaXRlCiAgIG1vdW50IC9zeXNyb290ICR0bXAgLW8gYmluZAogICBtb3VudCAkdG1wIC1vIHJlbW91bnQscncKICAgIyBXaXRoIHNvbWUgdmVyc2lvbnMgb2Ygb3N0cmVlIHRoZSBzeXNyb290IGRpcmVjdG9yeSBoYXMgdGhlIGltbXV0YWJsZQogICAjIGF0dHJpYnV0ZSwgc28gaW4gY2FzZSBpdCBpcyBwcmVzZW50LCB3ZSBuZWVkIHRvIHJlbW92ZSBpdCwgYW5kIG9uY2Ugd2UKICAgIyBjcmVhdGVkIHRoZSBkaXJlY3RvcnksIHdlIGNhbiBzZXQgaXQgYmFjawogICBpZiBsc2F0dHIgLWQgJHRtcCB8IGN1dCAtZCAnICcgLWYgMSB8IGdyZXAgaTsgdGhlbgogICAgICAgY2hhdHRyIC1pICR0bXAKICAgICAgIG1rZGlyIC1wICIkdG1wLyRkaXIiCiAgICAgICBjaGF0dHIgK2kgJHRtcAogICBlbHNlCiAgICAgICBta2RpciAtcCAiJHRtcC8kZGlyIgogICBmaQogICB1bW91bnQgJHRtcAogICBybWRpciAkdG1wCmZpCg==
+            source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAojCiMgVGhpcyBzY3JpcHQgd2lsbCBjcmVhdGUgdW5kZXIgL3N5c3Jvb3QgYSBkaXJlY3RvcnkgdGhhdCB3aWxsIGJlIHVzZWQgdG8gc2hhcmUKIyBjb250YWluZXJzIGJldHdlZW4gdGhlIGRpZmZlcmVudCBzdGF0ZXJvb3RzCiMKc2V0IC14CmRpcj1jb250YWluZXJzCiMgSWYgdGhlIGRlc3RpbmF0aW9uIHNoYXJlZCBkaXIgZG9lcyBub3QgZXhpc3QsIHdlIG5lZWQgdG8gY3JlYXRlIGl0CmlmIFtbICEgLWQgL3N5c3Jvb3QvIiRkaXIiIF1dOyB0aGVuCiAgIGVjaG8gIi9zeXNyb290LyRkaXIgbm90IGV4aXN0aW5nLCBjcmVhdGluZyIKICAgZWNobyAiRnJlZWluZyBzcGFjZSBpbiBwcmV2aW91cyAvdmFyL2xpYi9jb250YWluZXJzIgogICAjIEZpcnN0IHdlIHdpbGwgZGVsZXRlIHRoZSBjb250ZW50cyBvZiB0aGUgb2xkIC92YXIvbGliL2NvbnRhaW5lcnMgdG8gbm90CiAgICMgaGF2ZSBoaWRkZW4gdXNlZCBzcGFjZSwgc2luY2Ugd2Ugd2lsbCBtb3VudCBvbiB0b3Agb2YgaXQKICAgcm0gLWZyIC92YXIvbGliL2NvbnRhaW5lcnMvKgogICBtb3VudCAvc3lzcm9vdCAtbyByZW1vdW50LHJ3CiAgICMgV2l0aCBzb21lIHZlcnNpb25zIG9mIG9zdHJlZSB0aGUgc3lzcm9vdCBkaXJlY3RvcnkgaGFzIHRoZSBpbW11dGFibGUKICAgIyBhdHRyaWJ1dGUsIHNvIGluIGNhc2UgaXQgaXMgcHJlc2VudCwgd2UgbmVlZCB0byByZW1vdmUgaXQsIGFuZCBvbmNlIHdlCiAgICMgY3JlYXRlZCB0aGUgZGlyZWN0b3J5LCB3ZSBjYW4gc2V0IGl0IGJhY2sKICAgaWYgbHNhdHRyIC1kIC9zeXNyb290IHwgY3V0IC1kICcgJyAtZiAxIHwgZ3JlcCBpOyB0aGVuCiAgICAgICBjaGF0dHIgLWkgL3N5c3Jvb3QKICAgICAgIG1rZGlyIC1wICIvc3lzcm9vdC8kZGlyIgogICAgICAgY2hhdHRyICtpIC9zeXNyb290CiAgIGVsc2UKICAgICAgIG1rZGlyIC1wICIvc3lzcm9vdC8kZGlyIgogICBmaQogICBjaGNvbiAtLXJlZmVyZW5jZT0vdmFyL2xpYi9jb250YWluZXJzICIvc3lzcm9vdC8kZGlyIgpmaQoK
 
-# Contents of the create_shared_containers_dir.sh script:
+# Contents of create_shared_containers_dir.sh script:
 #
 ##!/usr/bin/env bash
 ##
@@ -36,23 +36,18 @@ spec:
 #   # First we will delete the contents of the old /var/lib/containers to not
 #   # have hidden used space, since we will mount on top of it
 #   rm -fr /var/lib/containers/*
-#   tmp=$(mktemp -d)
-#   # /sysroot is read-only, and if we remount it readwrite, we wont be able to revert it back to read-only
-#   # to overcome this, we will do a bind mount somewhere else, and change that new mount to read-write
-#   mount /sysroot $tmp -o bind
-#   mount $tmp -o remount,rw
+#   mount /sysroot -o remount,rw
 #   # With some versions of ostree the sysroot directory has the immutable
 #   # attribute, so in case it is present, we need to remove it, and once we
 #   # created the directory, we can set it back
-#   if lsattr -d $tmp | cut -d ' ' -f 1 | grep i; then
-#       chattr -i $tmp
-#       mkdir -p "$tmp/$dir"
-#       chattr +i $tmp
+#   if lsattr -d /sysroot | cut -d ' ' -f 1 | grep i; then
+#       chattr -i /sysroot
+#       mkdir -p "/sysroot/$dir"
+#       chattr +i /sysroot
 #   else
-#       mkdir -p "$tmp/$dir"
+#       mkdir -p "/sysroot/$dir"
 #   fi
-#   umount $tmp
-#   rmdir $tmp
+#   chcon --reference=/var/lib/containers "/sysroot/$dir"
 #fi
 
     # We need to run several things in the proper order. We will use systemd dependencies to achieve it
@@ -67,7 +62,7 @@ spec:
           [Service]
           Type=oneshot
           RemainAfterExit=yes
-          ExecStart=/usr/local/bin/create_shared_containers_dir.sh
+          ExecStart=/bin/unshare -m /usr/local/bin/create_shared_containers_dir.sh
           [Install]
           WantedBy=local-fs.target
         enabled: true


### PR DESCRIPTION
- Move some variable definitions after including the .config-override file, so the contents of that file have more priority
- With https://github.com/rh-ecosystem-edge/ib-orchestrate-vm/pull/57 we broke directory-based /var/lib/container sharing. I fixed it, and in the process made it simpler