### PR TITLE
Make ibi-logs exit when the IBI script finished successfully

### DIFF
--- a/Makefile.ibi
+++ b/Makefile.ibi
@@ -85,7 +85,7 @@ ibi-vm-remove: vm-remove ## Remove IBI VM and the storage associated with it
 ibi-logs: ## Show logs of the IBI installation process
 	echo "Waiting for $(IBI_VM_NAME) to be accessible"
 	@until ssh $(SSH_FLAGS) core@$(IBI_VM_NAME) true; do sleep 5; echo -n .; done; echo
-	ssh $(SSH_FLAGS) core@$(IBI_VM_NAME) sudo journalctl -flu install-rhcos-and-restore-seed.service
+	ssh $(SSH_FLAGS) core@$(IBI_VM_NAME) "sudo journalctl -flu install-rhcos-and-restore-seed.service | stdbuf -o0 -e0 awk '{print \$$0 } /Finished SNO Image Based Installation./ { exit }'"
 
 .PHONY: ibi-certs
 ibi-certs:


### PR DESCRIPTION
This way we can streamline the whole IBI flow:

```make ibi-iso ibi-vm-remove ibi-vm ibi-logs ibi-config.iso ibi-attach-config.iso ibi-reboot```

Thanks for coming up with a simple solution for breaking the journalctl command @jeff-roche 

/cc @jeff-roche 

