### PR TITLE
The API of disabling rollbacks have changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ SNO_DIR = ./bip-orchestrate-vm
 # Define precache mode (partition or directory)
 PRECACHE_MODE ?= partition
 
-# Define the rollback mode
-DISABLE_IBU_ROLLBACK ?= false
+# Set to Disabled to disable IBU rollback (case sensitive)
+IBU_ROLLBACK ?= Enabled
 
 include network.env
 
@@ -375,7 +375,7 @@ lca-stage-idle: credentials/backup-secret.json
 	$(oc) create secret generic seed-pull-secret -n openshift-lifecycle-agent --from-file=.dockerconfigjson=credentials/backup-secret.json \
 		--type=kubernetes.io/dockerconfigjson --dry-run=client -oyaml \
 		| $(oc) apply -f -
-	SEED_VERSION=$(SEED_VERSION) SEED_IMAGE=$(SEED_IMAGE) DISABLE_IBU_ROLLBACK=$(DISABLE_IBU_ROLLBACK) envsubst < imagebasedupgrade.yaml | $(oc) apply -f -
+	SEED_VERSION=$(SEED_VERSION) SEED_IMAGE=$(SEED_IMAGE) IBU_ROLLBACK=$(IBU_ROLLBACK) envsubst < imagebasedupgrade.yaml | $(oc) apply -f -
 
 .PHONY: lca-stage-prep
 lca-stage-prep: CLUSTER=$(RECIPIENT_VM_NAME)

--- a/imagebasedupgrade.yaml
+++ b/imagebasedupgrade.yaml
@@ -2,6 +2,10 @@ apiVersion: lca.openshift.io/v1alpha1
 kind: ImageBasedUpgrade
 metadata:
   name: upgrade
+  annotations:
+    auto-rollback-on-failure.lca.openshift.io/post-reboot-config: ${IBU_ROLLBACK}
+    auto-rollback-on-failure.lca.openshift.io/upgrade-completion: ${IBU_ROLLBACK}
+    auto-rollback-on-failure.lca.openshift.io/init-monitor: ${IBU_ROLLBACK}
 spec:
   stage: Idle
   seedImageRef:
@@ -9,7 +13,3 @@ spec:
     image: ${SEED_IMAGE}
     pullSecretRef:
       name: seed-pull-secret
-  autoRollbackOnFailure:
-    disabledForPostRebootConfig: ${DISABLE_IBU_ROLLBACK}
-    disabledForUpgradeCompletion: ${DISABLE_IBU_ROLLBACK}
-    disabledInitMonitor: ${DISABLE_IBU_ROLLBACK}


### PR DESCRIPTION
See https://github.com/openshift-kni/lifecycle-agent/pull/433

Will also fix CI to use the new variable in a separate PR (no need to wait as CI is already broken)