### PR TITLE
Update ImageBasedUpgrade and SeedGenerator objects to apiVersion lca.openshift.io/v1

### DIFF
--- a/imagebasedupgrade.yaml
+++ b/imagebasedupgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: lca.openshift.io/v1alpha1
+apiVersion: lca.openshift.io/v1
 kind: ImageBasedUpgrade
 metadata:
   name: upgrade

--- a/seedgenerator.yaml
+++ b/seedgenerator.yaml
@@ -10,7 +10,7 @@ data:
   # hubKubeconfig: ${HUB_KUBECONFIG}
 
 ---
-apiVersion: lca.openshift.io/v1alpha1
+apiVersion: lca.openshift.io/v1
 kind: SeedGenerator
 metadata:
   name: seedimage


### PR DESCRIPTION
There is a version upgrade in LCA objects

We need to merge this PR right after https://github.com/openshift-kni/lifecycle-agent/pull/497 is merged into LCA