### PR TITLE
Adjust the IBI readme to create config ISO with the OCP installer changes

### DIFF
--- a/Makefile.ibi
+++ b/Makefile.ibi
@@ -162,7 +162,7 @@ $(IBI_WORK_DIR)/imagebasedconfig.iso: ibi-install-config ibi-imagebased-config
 	sudo cp $@ $(LIBVIRT_IMAGE_PATH)
 
 .PHONY: ibi-attach-config.iso
-ibi-attach-config.iso: ## Attach ibi-config.iso file to IBI VM
+ibi-attach-config.iso: ## Attach imagebasedconfig.iso file to IBI VM
 	$(virsh) change-media $(IBI_VM_NAME) --config sda $(LIBVIRT_IMAGE_PATH)/imagebasedconfig.iso
 
 .PHONY: ibi-reboot

--- a/README.ibi.md
+++ b/README.ibi.md
@@ -56,11 +56,11 @@ Jan 01 08:12:18 ibi systemd[1]: Finished SNO Image Based Installation.
 4. Generate the configuration ISO and attach it to the VM
 
 ```bash
-make ibi-config.iso
+make imagebasedconfig.iso
 make ibi-attach-config.iso
 ```
 
-after generating the ibi-config.iso you can find the kubeconfig for the installation under kubeconfig.ibi
+after generating the imagebasedconfig.iso you can find the kubeconfig for the installation under `ibi-iso-work-dir/auth/kubeconfig`.
 
 5. Reboot VM
 
@@ -73,7 +73,7 @@ After few minutes your cluster should be ready.
 6. Use oc to query the API:
 
 ```bash
-[coreos-installer]# oc --kubeconfig kubeconfig.ibi get node
+[coreos-installer]# oc --kubeconfig ibi-iso-work-dir/auth/kubeconfig get node
 NAME   STATUS   ROLES                         AGE   VERSION
 ibi    Ready    control-plane,master,worker   15m   v1.27.8+4fab27b
 ```


### PR DESCRIPTION
This PR adjusts minor IBI readme config ISO name references and the IBI kubeconfig location to the changes adding the IBI config ISO creation via the OCP installer - https://github.com/rh-ecosystem-edge/ib-orchestrate-vm/pull/74.