### PR TITLE
Extract openshift-install from a release image instead of building it

### DIFF
--- a/Makefile.ibi
+++ b/Makefile.ibi
@@ -15,11 +15,8 @@ IBI_WORK_DIR ?= ibi-iso-work-dir
 IBI_INSTALL_CONFIG ?= $(IBI_WORK_DIR)/install-config.yaml
 IBI_KUBECONFIG = $(IBI_WORK_DIR)/auth/kubeconfig
 
-OPENSHIFT_INSTALLER_REPO ?= https://github.com/openshift/installer
-OPENSHIFT_INSTALLER_BRANCH ?= master
-
-OPENSHIFT_INSTALLER_DIR ?= openshift-installer
-OPENSHIFT_INSTALLER_BIN ?= $(OPENSHIFT_INSTALLER_DIR)/bin/openshift-install
+OPENSHIFT_INSTALLER_RELEASE_IMAGE ?= quay.io/openshift-release-dev/ocp-release:4.17.0-ec.3-x86_64
+OPENSHIFT_INSTALLER_BIN ?= bin/openshift-install
 
 # Used to populate releaseRegistry in imagebased-config.yaml
 IBI_RELEASE_REGISTRY ?= quay.io
@@ -40,19 +37,14 @@ endif
 IBI_RHCOS_ISO_PATH = $(LIBVIRT_IMAGE_PATH)/rhcos-$(IBI_VM_NAME).iso
 
 .PHONY: ibi
-ibi: build-openshift-install ibi-iso ibi-vm ibi-logs imagebasedconfig.iso ibi-attach-config.iso ibi-reboot wait-for-ibi
+ibi: ibi-iso ibi-vm ibi-logs imagebasedconfig.iso ibi-attach-config.iso ibi-reboot wait-for-ibi
 
-.PHONY: openshift-installer
-openshift-installer:
-	@if [ -d $@ ]; then \
-		git -C $@ checkout -B $(OPENSHIFT_INSTALLER_BRANCH);\
-		git -C $@ pull;\
-	else \
-		git clone $(OPENSHIFT_INSTALLER_REPO) --branch $(OPENSHIFT_INSTALLER_BRANCH) $(OPENSHIFT_INSTALLER_DIR);\
-	fi
+$(OPENSHIFT_INSTALLER_BIN): credentials/pull-secret.json
+	oc adm release extract --registry-config=credentials/pull-secret.json --command=openshift-install --to ./bin $(OPENSHIFT_INSTALLER_RELEASE_IMAGE)
+	touch $(OPENSHIFT_INSTALLER_BIN)
 
 .PHONY: ibi-iso
-ibi-iso: $(SSH_KEY_PRIV_PATH) credentials/pull-secret.json image-based-installation-config.yaml ## Create ISO to be used in IBI
+ibi-iso: $(SSH_KEY_PRIV_PATH) $(OPENSHIFT_INSTALLER_BIN) credentials/pull-secret.json image-based-installation-config.yaml ## Create ISO to be used in IBI
 	mkdir -p $(IBI_WORK_DIR)
 	OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=$(IBI_RELEASE_IMAGE) $(OPENSHIFT_INSTALLER_BIN) image-based create image --dir $(IBI_WORK_DIR)
 	sudo cp $(IBI_WORK_DIR)/rhcos-ibi.iso "$(IBI_RHCOS_ISO_PATH)"
@@ -93,10 +85,6 @@ ibi-logs: ## Show logs of the IBI installation process
 	echo "Waiting for $(IBI_VM_NAME) to be accessible"
 	@until ssh $(SSH_FLAGS) core@$(IBI_VM_IP) true; do sleep 5; echo -n .; done; echo
 	ssh $(SSH_FLAGS) core@$(IBI_VM_IP) "sudo journalctl -flu install-rhcos-and-restore-seed.service | stdbuf -o0 -e0 awk '{print \$$0 } /Finished SNO Image Based Installation./ { exit }'"
-
-.PHONY: build-openshift-install
-build-openshift-install: openshift-installer ## Build openshift-install binary
-	cd openshift-installer && ./hack/build.sh
 
 .PHONY: image-based-installation-config.yaml
 image-based-installation-config.yaml: $(SSH_KEY_PRIV_PATH) ## Create image-based-installation-config.yaml
@@ -142,7 +130,7 @@ imagebasedconfig.iso: $(IBI_WORK_DIR)/imagebasedconfig.iso ## Create imagebasedc
 
 .PHONY: $(IBI_WORK_DIR)/imagebasedconfig.iso
 $(IBI_WORK_DIR)/imagebasedconfig.iso: RELEASE_VERSION=$(SEED_VERSION)
-$(IBI_WORK_DIR)/imagebasedconfig.iso: ibi-install-config ibi-imagebased-config
+$(IBI_WORK_DIR)/imagebasedconfig.iso: $(OPENSHIFT_INSTALLER_BIN) ibi-install-config ibi-imagebased-config
 	$(OPENSHIFT_INSTALLER_BIN) image-based create config-image --dir $(IBI_WORK_DIR)
 	sudo cp $@ $(LIBVIRT_IMAGE_PATH)
 


### PR DESCRIPTION
This PR extracts the `openshift-install` binary from a release image by default (defined by the `OPENSHIFT_INSTALLER_RELEASE_IMAGE` env var) or directly points to the desired openshift-install binary with the `OPENSHIFT_INSTALLER_BIN` env var, instead of cloning the OCP installer's `master` branch and building it.

### Context
Cloning the master branch of the installer and building the openshift-install binary introduced a failure to the IBI CI, because of the following:

- the IBI CI base images use Go 1.21, because LCA requires Go 1.21
- the image-based installer has been added to the OCP installer 4.17 release, which uses Go 1.22
- `GOTOOCHAIN=off` for the base images, which results in the openshift-install build failure as Go is not Go 1.22 and the toolchain won't download and use Go 1.22

### IBI CI failure resolution

In the IBI CI we will:

- add a dependency to the OCP 4.17 installer pull-spec
- use the OCP 4.17 installer pull-spec and extract the openshift-install binary from it (like what is done [here](https://github.com/openshift/release/blob/175294edb7adbd76157a5e009b0f946917546202/ci-operator/step-registry/openshift/image-based/upgrade/e2e/openshift-image-based-upgrade-e2e-commands.sh#L33-L38) for the openshift-tests binary)
- set the `OPENSHIFT_INSTALLER_BIN` env var to point to the extracted binary (and thus we won't use the `OPENSHIFT_INSTALLER_RELEASE_IMAGE` env var)

# IMPORTANT!

In order to successfully run IBI after this change, we need to provide an OCP 4.17 release that contains the latest `openshift-install` binary, by using an ec release >= 4.17.0-ec.3 or one of the recent 4.17 nightlies. For example, override the `OPENSHIFT_INSTALLER_RELEASE_IMAGE` with `OPENSHIFT_INSTALLER_RELEASE_IMAGE=registry.ci.openshift.org/ocp/release:4.17.0-0.nightly-2024-08-07-124849`.