### PR TITLE
Update oadp stable channel to 1.4 as 1.3 does not exist

### DIFF
--- a/oadp-operator.yaml
+++ b/oadp-operator.yaml
@@ -23,7 +23,7 @@ metadata:
   name: openshift-adp
   namespace: openshift-adp
 spec:
-  channel: stable-1.3
+  channel: stable-1.4
   installPlanApproval: Automatic
   approved: true
   name: redhat-oadp-operator


### PR DESCRIPTION
This PR updates the OADP OLM subscription channel to `stable-1.4`, as `stable-1.3` does not exist in OCP 4.16 anymore and this leads to the seed cluster preparation not succeeding.

```sh
$ oc get clusterversions
NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.16.7    True        False         11m     Cluster version is 4.16.7
$ oc get packagemanifests redhat-oadp-operator -oyaml |grep stable-
    name: stable-1.0
    name: stable-1.1
    name: stable-1.2
    name: stable-1.4
  defaultChannel: stable-1.4
```