### PR TITLE
MGMT-17967: fix ibi-logs target not exiting because of changed termination log message

### DIFF
--- a/Makefile.ibi
+++ b/Makefile.ibi
@@ -84,7 +84,7 @@ ibi-vm-remove: vm-remove ## Remove IBI VM and the storage associated with it
 ibi-logs: ## Show logs of the IBI installation process
 	echo "Waiting for $(IBI_VM_NAME) to be accessible"
 	@until ssh $(SSH_FLAGS) core@$(IBI_VM_IP) true; do sleep 5; echo -n .; done; echo
-	ssh $(SSH_FLAGS) core@$(IBI_VM_IP) "sudo journalctl -flu install-rhcos-and-restore-seed.service | stdbuf -o0 -e0 awk '{print \$$0 } /Finished SNO Image Based Installation./ { exit }'"
+	ssh $(SSH_FLAGS) core@$(IBI_VM_IP) "sudo journalctl -flu install-rhcos-and-restore-seed.service | stdbuf -o0 -e0 awk '{print \$$0 } /Finished SNO Image-based Installation./ { exit }'"
 
 .PHONY: image-based-installation-config.yaml
 image-based-installation-config.yaml: $(SSH_KEY_PRIV_PATH) ## Create image-based-installation-config.yaml


### PR DESCRIPTION
This PR fixes the `ibi-logs` target not terminating because of a change in the log message it's waiting for. :)