### PR TITLE
Use the defaultChannel for the OADP OLM Subscription

### DIFF
--- a/oadp-operator.yaml
+++ b/oadp-operator.yaml
@@ -23,7 +23,6 @@ metadata:
   name: openshift-adp
   namespace: openshift-adp
 spec:
-  channel: stable-1.4
   installPlanApproval: Automatic
   approved: true
   name: redhat-oadp-operator


### PR DESCRIPTION
Since a default channel is specified in the package manifest of the OADP operator OLM bundleL

```shell
$ oc get packagemanifests redhat-oadp-operator -oyaml |grep defaultChannel
  defaultChannel: stable-1.4
```
we can use it to get the latest stable version of the latter.  This way we won't have to update the `Subscription` whenever a new version comes up or a channel we are currently using suddenly disappears.

/cc @tsorya @javipolo 