### PR TITLE
Ensure operator-sdk is present when deploying LCA from bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,6 +376,7 @@ credentials/pull-secret.json:
 lifecycle-agent-deploy: lifecycle-agent
 	@export KUBECONFIG=../$(SNO_KUBECONFIG); \
 	if [ -n $(LCA_OPERATOR_BUNDLE_IMAGE) ]; then \
+		make -C lifecycle-agent operator-sdk; \
 		BUNDLE_IMG=$(LCA_OPERATOR_BUNDLE_IMAGE) \
 			make -C lifecycle-agent bundle-run ;\
 	else \


### PR DESCRIPTION
This PR ensures that operator-sdk is present when deploying LCA via an operator bundle. The proper way would be to add this dependency in the LCA Makefile rule `bundle-run`, but until this change is merged in the LCA repo and all its release branches, I suggest we merge this to fix the broken IBU/IBI CI. 