### PR TITLE
Create LCA bin dir if not exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,6 +376,7 @@ credentials/pull-secret.json:
 lifecycle-agent-deploy: lifecycle-agent
 	@export KUBECONFIG=../$(SNO_KUBECONFIG); \
 	if [ -n $(LCA_OPERATOR_BUNDLE_IMAGE) ]; then \
+		mkdir -p lifecycle-agent/bin; \
 		make -C lifecycle-agent operator-sdk; \
 		BUNDLE_IMG=$(LCA_OPERATOR_BUNDLE_IMAGE) \
 			make -C lifecycle-agent bundle-run ;\


### PR DESCRIPTION
This change creates the `lifecycle-agent/bin` directory when the operator bundle is used to deploy LCA. The LCA Makefile `operator-sdk` rule assumes that that directory is already present when downloading the `operator-sdk` binary to the latter.