### PR TITLE
MGMT-19314: we should set valid static network for ibi installation flow

### DIFF
--- a/Makefile.ibi
+++ b/Makefile.ibi
@@ -94,6 +94,9 @@ image-based-installation-config.yaml: $(SSH_KEY_PRIV_PATH) ## Create image-based
 	@< $(IBI_INSTALLATION_CONFIG_TEMPLATE) \
 		SEED_IMAGE=$(SEED_IMAGE) \
 		SEED_VERSION=$(SEED_VERSION) \
+		HOST_IP=$(IBI_VM_IP) \
+		HOST_MAC=$(IBI_VM_MAC) \
+		HOST_ROUTE=$(shell $(virsh) net-dumpxml $(IBI_NET_NAME) | grep '<ip ' | xargs -n1 | grep address | cut -d = -f 2) \
 		PULL_SECRET='$(PULL_SECRET)' \
 		INSTALLATION_DISK=$(IBI_INSTALLATION_DISK) \
 		SSH_KEY='$(shell cat $(SSH_KEY))' \

--- a/image-based-installation-config-template.yaml
+++ b/image-based-installation-config-template.yaml
@@ -12,16 +12,24 @@ seedVersion: "${SEED_VERSION}"
 installationDisk: "${INSTALLATION_DISK}"
 networkConfig:
   interfaces:
-    - name: eth0
+    - name: enp1s0
       type: ethernet
       state: up
-      mac-address: 00:00:00:00:00:00
+      mac-address: ${HOST_MAC}
       ipv4:
         enabled: true
         address:
-          - ip: 192.168.122.2
-            prefix-length: 23
-        dhcp: false
+          - ip: ${HOST_IP}
+            prefix-length: 24
+  routes:
+    config:
+      - next-hop-address: ${HOST_ROUTE}
+        next-hop-interface: enp1s0
+        destination: 0.0.0.0/0
+  dns-resolver:
+    config:
+      server:
+        - ${HOST_ROUTE}
 pullSecret: |
   ${PULL_SECRET}
 sshKey: |


### PR DESCRIPTION
 Currently when we create configuration in order to write seed image to disk ,
ib-orchestrate provides wrong static networking and we use libvirt dhcp though we want to use static network