### PR TITLE
MGMT-19314: remove static network from image-based-installation-config.yaml

### DIFF
--- a/image-based-installation-config-template.yaml
+++ b/image-based-installation-config-template.yaml
@@ -10,18 +10,6 @@ metadata:
 seedImage: "${SEED_IMAGE}"
 seedVersion: "${SEED_VERSION}"
 installationDisk: "${INSTALLATION_DISK}"
-networkConfig:
-  interfaces:
-    - name: eth0
-      type: ethernet
-      state: up
-      mac-address: 00:00:00:00:00:00
-      ipv4:
-        enabled: true
-        address:
-          - ip: 192.168.122.2
-            prefix-length: 23
-        dhcp: false
 pullSecret: |
   ${PULL_SECRET}
 sshKey: |


### PR DESCRIPTION
MGMT-19314: remove static network from image-based-installation-config.yaml

We don't want to validate static networking in this part as it is less critical and requires different configurations for IBI and IBIO as IBIO runs with dev-scripts network.
Till now static network was failing and we dropped to dhcp, from this point we will just go with dhcp