### PR TITLE
MGMT-20644: Set empty default IBI release registry

### DIFF
--- a/Makefile.ibi
+++ b/Makefile.ibi
@@ -19,7 +19,7 @@ OPENSHIFT_INSTALLER_RELEASE_IMAGE ?= quay.io/openshift-release-dev/ocp-release:4
 OPENSHIFT_INSTALLER_BIN ?= bin/openshift-install
 
 # Used to populate releaseRegistry in imagebased-config.yaml
-IBI_RELEASE_REGISTRY ?= quay.io
+IBI_RELEASE_REGISTRY ?= ""
 
 IBI_RELEASE_IMAGE ?= $(DEFAULT_RELEASE_IMAGE)
 IBI_INSTALLATION_CONFIG_TEMPLATE = image-based-installation-config-template.yaml


### PR DESCRIPTION
When setting this default to quay.io and the seed image is generated with a CI release registry, i.e. registry.ci.openshift.org, the IBI SNO reconfiguration ends up with a non-existent cluster-version-operator image pull-spec. The result is an SNO with a non-running CVO, thus the installation never succeeds (even if all other components are healthy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the default registry value for image-based releases to be empty instead of pre-filled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->