### PR TITLE
Update LCA bundle ref for target prepare

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,6 +265,7 @@ target-lifecycle-agent-deploy: lifecycle-agent-deploy
 
 .PHONY: target-cluster-prepare
 target-cluster-prepare: CLUSTER=$(TARGET_VM_NAME)
+target-cluster-prepare: LCA_OPERATOR_BUNDLE_IMAGE=$(TARGET_LCA_REF)
 target-cluster-prepare: target-directory-varlibcontainers target-oadp-deploy target-lifecycle-agent-deploy ## Prepare target VM cluster
 
 .PHONY: target-directory-varlibcontainers


### PR DESCRIPTION
Use previous release version instead of PR version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable assignment for the target-cluster-prepare process to improve configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->