### PR TITLE
Revert "Update LCA bundle ref for target prepare"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,6 @@ target-lifecycle-agent-deploy: lifecycle-agent-deploy
 
 .PHONY: target-cluster-prepare
 target-cluster-prepare: CLUSTER=$(TARGET_VM_NAME)
-target-cluster-prepare: LCA_OPERATOR_BUNDLE_IMAGE=$(TARGET_LCA_REF)
 target-cluster-prepare: target-directory-varlibcontainers target-oadp-deploy target-lifecycle-agent-deploy ## Prepare target VM cluster
 
 .PHONY: target-directory-varlibcontainers


### PR DESCRIPTION
Reverts rh-ecosystem-edge/ib-orchestrate-vm#102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build process to simplify variable handling during cluster preparation. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->