### PR TITLE
Initialize the submodule as part of the lifecycle-agent target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,13 @@ bip-orchestrate-vm:
 .PHONY: lifecycle-agent
 lifecycle-agent:
 	@if [ -d $@ ]; then \
-		git -C $@ pull ;\
+		git -C $@ pull && \
+		git -C $@ submodule sync --recursive && \
+		git -C $@ submodule update --init --recursive --remote; \
 	else \
-		git clone $(LCA_GIT_REPO) --branch $(LCA_GIT_BRANCH) lifecycle-agent;\
+		git clone $(LCA_GIT_REPO) --branch $(LCA_GIT_BRANCH) lifecycle-agent && \
+		git -C lifecycle-agent submodule sync --recursive && \
+		git -C lifecycle-agent submodule update --init --recursive --remote; \
 	fi
 
 ## VM provision in a single step


### PR DESCRIPTION
- This is required as the submodule is being introduced to that project
- If the submodule is not initialized then the scripts will fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved synchronization of the lifecycle-agent and its submodules to ensure they are always fully updated and initialized during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->