### PR TITLE
Update the pattern for matching ibi completion

### DIFF
--- a/Makefile.ibi
+++ b/Makefile.ibi
@@ -138,11 +138,11 @@ ifdef IBI_DHCP
 	echo "Got DHCP IP: $$IBI_LOG_IP" && \
 	echo "Waiting for $(IBI_VM_NAME) to be accessible" && \
 	until ssh $(SSH_FLAGS) core@$$IBI_LOG_IP true 2>/dev/null; do sleep 5; echo -n .; done && echo && \
-	ssh $(SSH_FLAGS) core@$$IBI_LOG_IP "sudo journalctl -flu install-rhcos-and-restore-seed.service | stdbuf -o0 -e0 awk '{print \$$0 } /Finished SNO Image-based Installation./ { exit }'"
+	ssh $(SSH_FLAGS) core@$$IBI_LOG_IP "sudo journalctl -flu install-rhcos-and-restore-seed.service | stdbuf -o0 -e0 awk '{print \$$0 } /Finished.*SNO Image-based Installation/ { exit }'"
 else
 	@echo "Waiting for $(IBI_VM_NAME) to be accessible"
 	@until ssh $(SSH_FLAGS) core@$(IBI_VM_IP_$(STACK_PRIMARY_FAM)) true; do sleep 5; echo -n .; done; echo
-	ssh $(SSH_FLAGS) core@$(IBI_VM_IP_$(STACK_PRIMARY_FAM)) "sudo journalctl -flu install-rhcos-and-restore-seed.service | stdbuf -o0 -e0 awk '{print \$$0 } /Finished SNO Image-based Installation./ { exit }'"
+	ssh $(SSH_FLAGS) core@$(IBI_VM_IP_$(STACK_PRIMARY_FAM)) "sudo journalctl -flu install-rhcos-and-restore-seed.service | stdbuf -o0 -e0 awk '{print \$$0 } /Finished.*SNO Image-based Installation/ { exit }'"
 endif
 
 .PHONY: image-based-installation-config.yaml


### PR DESCRIPTION
On ocp 5, service name gets inserted in the middle:
`Jun 18 15:04:49 target.ibo1.redhat.com systemd[1]: Finished install-rhcos-and-restore-seed.service - SNO Image-based Installation.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated log filtering patterns used during SNO Image-based Installation for improved log capture consistency across deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->